### PR TITLE
Test data fix: validation-simple-code-good system param, valueUri instead of valueCanonical

### DIFF
--- a/tests/validation/simple-code-good-request-parameters.json
+++ b/tests/validation/simple-code-good-request-parameters.json
@@ -8,6 +8,6 @@
     "valueCode" : "code1"
   },{
     "name" : "system",
-    "valueCanonical" : "http://hl7.org/fhir/test/CodeSystem/simple"
+    "valueUri" : "http://hl7.org/fhir/test/CodeSystem/simple"
   }]
 }


### PR DESCRIPTION
Fixing validation-simple-code-good test input data for "system" parameter, passing "valueUri" instead of "valueCanonical"