### PR TITLE
fixing validation-simple-code-good-regex test system type: valueUri

### DIFF
--- a/tests/validation/simple-code-good-regex-request-parameters.json
+++ b/tests/validation/simple-code-good-regex-request-parameters.json
@@ -8,6 +8,6 @@
     "valueCode" : "code1"
   },{
     "name" : "system",
-    "valueCanonical" : "http://hl7.org/fhir/test/CodeSystem/simple"
+    "valueUri" : "http://hl7.org/fhir/test/CodeSystem/simple"
   }]
 }


### PR DESCRIPTION
Fixing `validation-simple-code-good-regex` test system type: `valueUri` instead of `valueCanonical`