### PR TITLE
parameters txTests need not to be prefixed withouth -

### DIFF
--- a/input/pagecontent/testcases.md
+++ b/input/pagecontent/testcases.md
@@ -16,7 +16,7 @@ execute the tests is to use the [standard Java FHIR Validator](https://github.co
 Run with the parameters:
 
 ````
--txTests -tx {server} -version? {version} -externals {file} -output {folder} -mode? {flat}?
+txTests -tx {server} -version? {version} -externals {file} -output {folder} -mode? {flat}?
 ````
 
 Notes:


### PR DESCRIPTION
to run the tests with the validator I need to remove the '-' from -txTests, otherwise it won't work .I  don't know if the documentation here should be corrected or the code in the validator. this PR fixeds the docu here.

in https://confluence.hl7.org/spaces/FHIR/pages/35718580/Using+the+FHIR+Validator the parameter is not described.