### PR TITLE
Allow optional version param in validate-code failure responses

### DIFF
--- a/tests/case/case-coding-sensitive-code1-3-response-parameters.json
+++ b/tests/case/case-coding-sensitive-code1-3-response-parameters.json
@@ -57,5 +57,10 @@
   {
     "name" : "system",
     "valueUri" : "http://hl7.org/fhir/test/CodeSystem/case-sensitive"
+  },
+  {
+    "$optional$" : true,
+    "name" : "version",
+    "valueString" : "0.1.0"
   }]
 }

--- a/tests/validation/cs-code-bad-code-response-parameters.json
+++ b/tests/validation/cs-code-bad-code-response-parameters.json
@@ -41,5 +41,10 @@
   {
     "name" : "system",
     "valueUri" : "http://hl7.org/fhir/test/CodeSystem/simple"
+  },
+  {
+    "$optional$" : true,
+    "name" : "version",
+    "valueString" : "0.1.0"
   }]
 }

--- a/tests/validation/simple-code-bad-code-response-parameters.json
+++ b/tests/validation/simple-code-bad-code-response-parameters.json
@@ -62,5 +62,10 @@
     "$optional$" : true,
     "name" : "system",
     "valueUri" : "http://hl7.org/fhir/test/CodeSystem/simple"
+  },
+  {
+    "$optional$" : true,
+    "name" : "version",
+    "valueString" : "0.1.0"
   }]
 }

--- a/tests/validation/simple-coding-bad-code-response-parameters.json
+++ b/tests/validation/simple-coding-bad-code-response-parameters.json
@@ -61,5 +61,10 @@
   {
     "name" : "system",
     "valueUri" : "http://hl7.org/fhir/test/CodeSystem/simple"
+  },
+  {
+    "$optional$" : true,
+    "name" : "version",
+    "valueString" : "0.1.0"
   }]
 }


### PR DESCRIPTION
## Summary
- Add optional `version` parameter to 4 validate-code failure response test expectations
- Servers may include the CodeSystem version even when validation fails; this makes it accepted but not required

### Files changed
- `tests/case/case-coding-sensitive-code1-3-response-parameters.json`
- `tests/validation/cs-code-bad-code-response-parameters.json`
- `tests/validation/simple-code-bad-code-response-parameters.json`
- `tests/validation/simple-coding-bad-code-response-parameters.json`

## Test plan
- [x] Verified Ontoserver passes these 4 tests with the change
- [x] Version parameter marked `$optional$: true` so servers that don't return it still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)