### PR TITLE
Update readme to remove server version flag

### DIFF
--- a/tests/readme.md
+++ b/tests/readme.md
@@ -26,7 +26,6 @@ java -jar {validator} -txtests -source {root folder for this repo} -tx {server t
 Other command line parameters for ```-txtests```:
 
 * ```-output {folder}```: A folder in witch to place the output of failing tests. Note that the output is in R5 format irrespective of the version of the server running, and mimics the folder structure of the input, so that you can diff the input and output to see the differences
-* ```-version {v}```: The version of the server. R3, R4, and R5 are supported. 
 * ```-externals {file}``` : The file in which external strings are found. Different servers have slightly different error messages. In the absence of external strings, only the pattern is tested
 * ```-filter {string}```: If this is provided, only test names that include this string will be executed (to make testing faster)
 * ```-modes {string(,string)}```:  If this is provided, the tests with the specified mode (in the suite in test-case.json) will be executed


### PR DESCRIPTION
The version flag is not supported in the latest version of the validator jar.