### PR TITLE
Accept any validating coding in multi-coding CodeableConcept tests (good-cc2)

### DIFF
--- a/tests/permutations/simple-good-cc2-all-response-parameters.json
+++ b/tests/permutations/simple-good-cc2-all-response-parameters.json
@@ -2,7 +2,7 @@
   "resourceType" : "Parameters",
   "parameter" : [{
       "name" : "code",
-      "valueCode" : "code3"
+      "valueCode" : "$choice:code1|code3$"
     },
     {
       "name" : "codeableConcept",
@@ -21,7 +21,7 @@
     },
     {
       "name" : "display",
-      "valueString" : "Display 3"
+      "valueString" : "$choice:Display 1|Display 3$"
     },
     {
       "name" : "result",

--- a/tests/permutations/simple-good-cc2-enumerated-response-parameters.json
+++ b/tests/permutations/simple-good-cc2-enumerated-response-parameters.json
@@ -2,7 +2,7 @@
   "resourceType" : "Parameters",
   "parameter" : [{
       "name" : "code",
-      "valueCode" : "code3"
+      "valueCode" : "$choice:code1|code3$"
     },
     {
       "name" : "codeableConcept",
@@ -21,7 +21,7 @@
     },
     {
       "name" : "display",
-      "valueString" : "Display 3"
+      "valueString" : "$choice:Display 1|Display 3$"
     },
     {
       "name" : "result",

--- a/tests/permutations/simple-good-cc2-exclude-filter-response-parameters.json
+++ b/tests/permutations/simple-good-cc2-exclude-filter-response-parameters.json
@@ -2,7 +2,7 @@
   "resourceType" : "Parameters",
   "parameter" : [{
       "name" : "code",
-      "valueCode" : "code3"
+      "valueCode" : "$choice:code1|code3$"
     },
     {
       "name" : "codeableConcept",
@@ -21,7 +21,7 @@
     },
     {
       "name" : "display",
-      "valueString" : "Display 3"
+      "valueString" : "$choice:Display 1|Display 3$"
     },
     {
       "name" : "result",

--- a/tests/permutations/simple-good-cc2-exclude-import-response-parameters.json
+++ b/tests/permutations/simple-good-cc2-exclude-import-response-parameters.json
@@ -2,7 +2,7 @@
   "resourceType" : "Parameters",
   "parameter" : [{
       "name" : "code",
-      "valueCode" : "code3"
+      "valueCode" : "$choice:code1|code3$"
     },
     {
       "name" : "codeableConcept",
@@ -21,7 +21,7 @@
     },
     {
       "name" : "display",
-      "valueString" : "Display 3"
+      "valueString" : "$choice:Display 1|Display 3$"
     },
     {
       "name" : "result",

--- a/tests/permutations/simple-good-cc2-exclude-list-response-parameters.json
+++ b/tests/permutations/simple-good-cc2-exclude-list-response-parameters.json
@@ -2,7 +2,7 @@
   "resourceType" : "Parameters",
   "parameter" : [{
       "name" : "code",
-      "valueCode" : "code3"
+      "valueCode" : "$choice:code1|code3$"
     },
     {
       "name" : "codeableConcept",
@@ -21,7 +21,7 @@
     },
     {
       "name" : "display",
-      "valueString" : "Display 3"
+      "valueString" : "$choice:Display 1|Display 3$"
     },
     {
       "name" : "result",

--- a/tests/permutations/simple-good-cc2-import-response-parameters.json
+++ b/tests/permutations/simple-good-cc2-import-response-parameters.json
@@ -2,7 +2,7 @@
   "resourceType" : "Parameters",
   "parameter" : [{
       "name" : "code",
-      "valueCode" : "code3"
+      "valueCode" : "$choice:code1|code3$"
     },
     {
       "name" : "codeableConcept",
@@ -21,7 +21,7 @@
     },
     {
       "name" : "display",
-      "valueString" : "Display 3"
+      "valueString" : "$choice:Display 1|Display 3$"
     },
     {
       "name" : "result",


### PR DESCRIPTION
## Summary

The `good-cc2-*` permutation tests validate a `CodeableConcept` containing two codings that both validate (`code1` and `code3`, same CodeSystem/ValueSet), and the expected response pins `code`/`display` to the **last** coding (`code3` / `Display 3`).

The `$validate-code` spec doesn't appear to mandate *which* validating coding's metadata is echoed when more than one validates. Reporting the **first** validating coding is at least as defensible — and is what Ontoserver does — so pinning the *last* coding makes the test more prescriptive than the specification.

This relaxes the 6 affected `good-cc2-*` response fixtures to accept **any** validating coding via `$choice:`:

- `code` → `$choice:code1|code3$`
- `display` → `$choice:Display 1|Display 3$`

Scope: `good-cc2-isa` is a negative test (neither coding is in the value set) and is unaffected; the `bad-cc2-*` cases have a single valid coding and are unaffected. 6 files, 12/12 lines.

## Discussion

Raised on chat.fhir.org (terminology stream). Happy to adjust if the *last* coding is intended to be normative — but otherwise this lets a conformant server report either validating coding rather than a specific one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)